### PR TITLE
Desabilitar botão do microModal após POST

### DIFF
--- a/js/microModal.js
+++ b/js/microModal.js
@@ -80,7 +80,7 @@ class ModalHandler {
         if (form) {
             form.addEventListener('submit', (event) => {
                 event.preventDefault();
-		form.querySelector('input[name="report"]').setAttribute('disabled', 'disabled');
+		        form.querySelector('input[name="report"]').setAttribute('disabled', 'disabled');
                 const formData = new FormData(form);
                 formData.append('json_response', '1');
                 const xhr = new XMLHttpRequest();

--- a/js/microModal.js
+++ b/js/microModal.js
@@ -80,7 +80,7 @@ class ModalHandler {
         if (form) {
             form.addEventListener('submit', (event) => {
                 event.preventDefault();
-		        form.querySelector('input[name="report"]').setAttribute('disabled', 'disabled');
+		        form.querySelector('input[type="submit"]').setAttribute('disabled', 'disabled');
                 const formData = new FormData(form);
                 formData.append('json_response', '1');
                 const xhr = new XMLHttpRequest();

--- a/js/microModal.js
+++ b/js/microModal.js
@@ -80,6 +80,7 @@ class ModalHandler {
         if (form) {
             form.addEventListener('submit', (event) => {
                 event.preventDefault();
+		form.querySelector('input[name="report"]').setAttribute('disabled', 'disabled');
                 const formData = new FormData(form);
                 formData.append('json_response', '1');
                 const xhr = new XMLHttpRequest();
@@ -94,6 +95,7 @@ class ModalHandler {
                             setTimeout(() => this.closeModal(data?.redirect), 2000);
                         } else {
                             alert(data.error);
+                            setTimeout(() => this.closeModal(data?.redirect), 2000);
                         }
                     } else {
                         alert(_('An unexpected error occurred.'));


### PR DESCRIPTION
Depois de clicar em "Submit", tem um delay entre a resposta do servidor e o cliente, o que o usuário pode clicar em enviar duas vezes pensando que não foi enviado. 
Esse commit desabilita o botão após o trigger submit.